### PR TITLE
Add a workflow to get NHS APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+---
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
+        with:
+          python-version: '3.10'
+
+      - name: Update APIs
+        run: |
+          pip install -r requirements.txt
+          python scraper.py
+
+      - name: Publish
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          git add nhs-digital/apis
+          git diff-index --quiet HEAD || git commit -m 'Publish NHS apis'
+          git push


### PR DESCRIPTION
This will run once a day to scrape the NHS API catalogue, and will commit and
push the changes if there are any (if there are no changes nothing happens).